### PR TITLE
Make multiple slider

### DIFF
--- a/components/atoms/BaseCanvas.vue
+++ b/components/atoms/BaseCanvas.vue
@@ -12,6 +12,12 @@ export default {
     },
     colorRed() {
       return this.$store.state.canvasVariables.colorRed
+    },
+    colorGreen() {
+      return this.$store.state.canvasVariables.colorGreen
+    },
+    colorBlue() {
+      return this.$store.state.canvasVariables.colorBlue
     }
   },
   mounted() {
@@ -19,12 +25,16 @@ export default {
     this.$store.subscribe((mutation, state) => {
       if (
         mutation.type === 'updateRectSize' ||
-        mutation.type === 'updateColorRed'
+        mutation.type === 'updateColorRed' ||
+        mutation.type === 'updateColorGreen' ||
+        mutation.type === 'updateColorBlue'
       ) {
         const rectSize = state.canvasVariables.rectSize
         const colorRed = state.canvasVariables.colorRed
+        const colorGreen = state.canvasVariables.colorGreen
+        const colorBlue = state.canvasVariables.colorBlue
         ctx.clearRect(0, 0, 100, 100)
-        ctx.fillStyle = `rgb(${colorRed}, 0, 0)`
+        ctx.fillStyle = `rgb(${colorRed}, ${colorGreen}, ${colorBlue})`
         ctx.fillRect(0, 0, rectSize, rectSize)
       }
     })

--- a/components/atoms/BaseCanvas.vue
+++ b/components/atoms/BaseCanvas.vue
@@ -9,14 +9,22 @@ export default {
   computed: {
     rectSize() {
       return this.$store.state.canvasVariables.rectSize
+    },
+    colorRed() {
+      return this.$store.state.canvasVariables.colorRed
     }
   },
   mounted() {
     const ctx = this.$el.getContext('2d')
     this.$store.subscribe((mutation, state) => {
-      if (mutation.type === 'updateRectSize') {
+      if (
+        mutation.type === 'updateRectSize' ||
+        mutation.type === 'updateColorRed'
+      ) {
         const rectSize = state.canvasVariables.rectSize
+        const colorRed = state.canvasVariables.colorRed
         ctx.clearRect(0, 0, 100, 100)
+        ctx.fillStyle = `rgb(${colorRed}, 0, 0)`
         ctx.fillRect(0, 0, rectSize, rectSize)
       }
     })

--- a/components/molecules/ControllSlider.vue
+++ b/components/molecules/ControllSlider.vue
@@ -3,11 +3,11 @@
     <div class="slider-header">
       <div class="slider-name">{{ sliderName }}</div>
       <div class="slider-value">
-        {{ Math.round(rectSize.toString()) + unitName }}
+        {{ Math.round(value.toString()) + unitName }}
       </div>
     </div>
     <base-slider
-      :percentage="culcPercentage(rectSize, minValue, maxValue)"
+      :percentage="culcPercentage(value, minValue, maxValue)"
       @clickBar="clickBar($event)"
       @dotMove="dotMove($event)"
     ></base-slider>
@@ -23,17 +23,8 @@ export default {
     sliderName: { type: String, required: true, default: 'sliderName' },
     minValue: { type: Number, required: true, default: 0 },
     maxValue: { type: Number, required: true, default: 100 },
+    value: { type: Number, required: true, default: 50 },
     unitName: { type: String, required: false, default: '' }
-  },
-  data: () => {
-    return {
-      value: 30
-    }
-  },
-  computed: {
-    rectSize() {
-      return this.$store.state.canvasVariables.rectSize
-    }
   },
   methods: {
     culcPercentage(value, min, max) {
@@ -44,21 +35,21 @@ export default {
       const width = 208
       const range = this.maxValue - this.minValue
       const moveDistance = (e / width) * range
-      let newValue = this.rectSize + moveDistance
+      let newValue = this.value + moveDistance
       if (newValue < this.minValue) {
         newValue = this.minValue
       }
       if (newValue > this.maxValue) {
         newValue = this.maxValue
       }
-      this.$store.commit('updateRectSize', newValue)
+      this.$emit('updateValue', newValue)
     },
     clickBar(e) {
       const width = 208
       const range = this.maxValue - this.minValue
       const clickPosition = e.offsetX
       const newValue = this.minValue + (clickPosition / width) * range
-      this.$store.commit('updateRectSize', newValue)
+      this.$emit('updateValue', newValue)
     }
   }
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -6,7 +6,6 @@
     <div ref="main" class="main">
       <base-canvas
         ref="canvas"
-        :rect-size="rectSize"
         :width="mainWidth"
         :height="mainHeight"
       ></base-canvas>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -18,6 +18,11 @@
         :max-value="100"
         unit-name="px"
       ></controll-slider>
+      <controll-slider
+        slider-name="color"
+        :min-value="0"
+        :max-value="255"
+      ></controll-slider>
     </div>
   </div>
 </template>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -16,12 +16,16 @@
         slider-name="rectSize"
         :min-value="10"
         :max-value="100"
+        :value="rectSize"
         unit-name="px"
+        @updateValue="updateRectSize"
       ></controll-slider>
       <controll-slider
-        slider-name="color"
+        slider-name="colorRed"
         :min-value="0"
         :max-value="255"
+        :value="colorRed"
+        @updateValue="updateColorRed"
       ></controll-slider>
     </div>
   </div>
@@ -38,9 +42,16 @@ export default {
   },
   data() {
     return {
-      rectSize: 500,
       mainWidth: 0,
       mainHeight: 0
+    }
+  },
+  computed: {
+    rectSize() {
+      return this.$store.state.canvasVariables.rectSize
+    },
+    colorRed() {
+      return this.$store.state.canvasVariables.colorRed
     }
   },
   mounted() {
@@ -48,6 +59,14 @@ export default {
     const mainArea = this.$refs.main
     this.mainWidth = mainArea.offsetWidth
     this.mainHeight = mainArea.offsetHeight
+  },
+  methods: {
+    updateRectSize(newValue) {
+      this.$store.commit('updateRectSize', newValue)
+    },
+    updateColorRed(newValue) {
+      this.$store.commit('updateColorRed', newValue)
+    }
   }
 }
 </script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -27,6 +27,20 @@
         :value="colorRed"
         @updateValue="updateColorRed"
       ></controll-slider>
+      <controll-slider
+        slider-name="colorGreen"
+        :min-value="0"
+        :max-value="255"
+        :value="colorGreen"
+        @updateValue="updateColorGreen"
+      ></controll-slider>
+      <controll-slider
+        slider-name="colorBlue"
+        :min-value="0"
+        :max-value="255"
+        :value="colorBlue"
+        @updateValue="updateColorBlue"
+      ></controll-slider>
     </div>
   </div>
 </template>
@@ -52,6 +66,12 @@ export default {
     },
     colorRed() {
       return this.$store.state.canvasVariables.colorRed
+    },
+    colorGreen() {
+      return this.$store.state.canvasVariables.colorGreen
+    },
+    colorBlue() {
+      return this.$store.state.canvasVariables.colorBlue
     }
   },
   mounted() {
@@ -66,6 +86,12 @@ export default {
     },
     updateColorRed(newValue) {
       this.$store.commit('updateColorRed', newValue)
+    },
+    updateColorGreen(newValue) {
+      this.$store.commit('updateColorGreen', newValue)
+    },
+    updateColorBlue(newValue) {
+      this.$store.commit('updateColorBlue', newValue)
     }
   }
 }

--- a/store/index.js
+++ b/store/index.js
@@ -1,7 +1,9 @@
 export const state = () => ({
   canvasVariables: {
     rectSize: 50,
-    colorRed: 127
+    colorRed: 127,
+    colorGreen: 127,
+    colorBlue: 127
   }
 })
 
@@ -11,5 +13,11 @@ export const mutations = {
   },
   updateColorRed(state, value) {
     state.canvasVariables.colorRed = value
+  },
+  updateColorGreen(state, value) {
+    state.canvasVariables.colorGreen = value
+  },
+  updateColorBlue(state, value) {
+    state.canvasVariables.colorBlue = value
   }
 }

--- a/store/index.js
+++ b/store/index.js
@@ -1,11 +1,15 @@
 export const state = () => ({
   canvasVariables: {
-    rectSize: 30
+    rectSize: 50,
+    colorRed: 127
   }
 })
 
 export const mutations = {
   updateRectSize(state, value) {
     state.canvasVariables.rectSize = value
+  },
+  updateColorRed(state, value) {
+    state.canvasVariables.colorRed = value
   }
 }


### PR DESCRIPTION
既存の実装だとスライダーごとに別の値を表示・操作することができなかったため

- スライダーの値やミューテーションは親で管理
  - スライダー自体は Store を参照しないように変更
  - スライダーは親にイベントを送るだけ

という形に変更。