### PR TITLE
Fix slider interaction

### DIFF
--- a/components/atoms/BaseSlider.vue
+++ b/components/atoms/BaseSlider.vue
@@ -7,8 +7,6 @@
       class="dot"
       :style="{ left: percentage + '%' }"
       @mousedown="dotTouchStart($event)"
-      @mousemove="dotMove($event)"
-      @mouseup="dotTouchEnd($event)"
     ></div>
   </div>
 </template>
@@ -28,6 +26,9 @@ export default {
     dotTouchStart(e) {
       this.isMousedown = true
       this.lastPosition = e.clientX
+      document.addEventListener('mousemove', this.dotMove)
+      document.addEventListener('mouseup', this.dotTouchEnd)
+      e.preventDefault()
     },
     dotMove(e) {
       if (this.isMousedown !== true) {
@@ -40,6 +41,8 @@ export default {
     dotTouchEnd(e) {
       this.isMousedown = false
       this.lastPosition = 0
+      document.removeEventListener('mousemove', this.dotMove)
+      document.removeEventListener('mouseup', this.dotTouchEnd)
     }
   }
 }

--- a/components/atoms/BaseSlider.vue
+++ b/components/atoms/BaseSlider.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="slider" @mousedown="barTouchStart($event)">
-    <div class="bar">
+  <div class="slider">
+    <div class="bar" @mousedown="barTouchStart($event)">
       <div class="bar-left" :style="{ width: percentage + '%' }"></div>
     </div>
     <div
@@ -65,7 +65,6 @@ export default {
   border-radius: 3px;
 }
 .bar-left {
-  width: 50%;
   height: 100%;
   background-color: $color-primary;
   border-radius: 3px 0 0 3px;

--- a/components/atoms/BaseSlider.vue
+++ b/components/atoms/BaseSlider.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="slider">
-    <div class="bar" @click="$emit('clickBar', $event)">
+  <div class="slider" @mousedown="barTouchStart($event)">
+    <div class="bar">
       <div class="bar-left" :style="{ width: percentage + '%' }"></div>
     </div>
     <div
@@ -43,6 +43,11 @@ export default {
       this.lastPosition = 0
       document.removeEventListener('mousemove', this.dotMove)
       document.removeEventListener('mouseup', this.dotTouchEnd)
+    },
+    barTouchStart(e) {
+      this.dotTouchStart(e)
+      this.$emit('clickBar', e)
+      e.preventDefault()
     }
   }
 }


### PR DESCRIPTION
child of #8 

- mousemove イベントと mouseup イベントを document に追加する形に変更
  - mouseup 時には両イベントを削除する
  - bar をタッチした際にも両イベントを登録し、そのままスライド操作を可能に