### PR TITLE
Render animation

### DIFF
--- a/components/atoms/BaseCanvas.vue
+++ b/components/atoms/BaseCanvas.vue
@@ -22,29 +22,34 @@ export default {
   },
   mounted() {
     this.ctx = this.$el.getContext('2d')
+    this.startTime = Date.now()
     setTimeout(() => {
-      this.render(this.rectSize, this.colorRed, this.colorGreen, this.colorBlue)
+      this.render()
     })
-    this.$store.subscribe((mutation, state) => {
-      if (
-        mutation.type === 'updateRectSize' ||
-        mutation.type === 'updateColorRed' ||
-        mutation.type === 'updateColorGreen' ||
-        mutation.type === 'updateColorBlue'
-      ) {
-        const rectSize = state.canvasVariables.rectSize
-        const colorRed = state.canvasVariables.colorRed
-        const colorGreen = state.canvasVariables.colorGreen
-        const colorBlue = state.canvasVariables.colorBlue
-        this.render(rectSize, colorRed, colorGreen, colorBlue)
-      }
-    })
+    // this.$store.subscribe((mutation, state) => {
+    //   if (
+    //     mutation.type === 'updateRectSize' ||
+    //     mutation.type === 'updateColorRed' ||
+    //     mutation.type === 'updateColorGreen' ||
+    //     mutation.type === 'updateColorBlue'
+    //   ) {
+    //     const rectSize = state.canvasVariables.rectSize
+    //     const colorRed = state.canvasVariables.colorRed
+    //     const colorGreen = state.canvasVariables.colorGreen
+    //     const colorBlue = state.canvasVariables.colorBlue
+    //     this.render(rectSize, colorRed, colorGreen, colorBlue)
+    //   }
+    // })
   },
   methods: {
-    render(size, red, green, blue) {
+    render() {
       this.ctx.clearRect(0, 0, 100, 100)
-      this.ctx.fillStyle = `rgb(${red}, ${green}, ${blue})`
-      this.ctx.fillRect(0, 0, size, size)
+      const nowTime = Date.now()
+      const ellapsedTime = (nowTime - this.startTime) / 1000
+      const blue = Math.abs(Math.sin(ellapsedTime) * 255)
+      this.ctx.fillStyle = `rgb(${this.colorRed}, ${this.colorGreen}, ${blue})`
+      this.ctx.fillRect(0, 0, this.rectSize, this.rectSize)
+      requestAnimationFrame(this.render)
     }
   }
 }

--- a/components/atoms/BaseCanvas.vue
+++ b/components/atoms/BaseCanvas.vue
@@ -23,23 +23,7 @@ export default {
   mounted() {
     this.ctx = this.$el.getContext('2d')
     this.startTime = Date.now()
-    setTimeout(() => {
-      this.render()
-    })
-    // this.$store.subscribe((mutation, state) => {
-    //   if (
-    //     mutation.type === 'updateRectSize' ||
-    //     mutation.type === 'updateColorRed' ||
-    //     mutation.type === 'updateColorGreen' ||
-    //     mutation.type === 'updateColorBlue'
-    //   ) {
-    //     const rectSize = state.canvasVariables.rectSize
-    //     const colorRed = state.canvasVariables.colorRed
-    //     const colorGreen = state.canvasVariables.colorGreen
-    //     const colorBlue = state.canvasVariables.colorBlue
-    //     this.render(rectSize, colorRed, colorGreen, colorBlue)
-    //   }
-    // })
+    this.render()
   },
   methods: {
     render() {

--- a/components/atoms/BaseCanvas.vue
+++ b/components/atoms/BaseCanvas.vue
@@ -16,8 +16,8 @@ export default {
     colorGreen() {
       return this.$store.state.canvasVariables.colorGreen
     },
-    colorBlue() {
-      return this.$store.state.canvasVariables.colorBlue
+    blueSpeed() {
+      return this.$store.state.canvasVariables.blueSpeed
     }
   },
   mounted() {
@@ -30,7 +30,7 @@ export default {
       this.ctx.clearRect(0, 0, 100, 100)
       const nowTime = Date.now()
       const ellapsedTime = (nowTime - this.startTime) / 1000
-      const blue = Math.abs(Math.sin(ellapsedTime) * 255)
+      const blue = Math.abs(Math.sin(ellapsedTime * this.blueSpeed) * 255)
       this.ctx.fillStyle = `rgb(${this.colorRed}, ${this.colorGreen}, ${blue})`
       this.ctx.fillRect(0, 0, this.rectSize, this.rectSize)
       requestAnimationFrame(this.render)

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -34,11 +34,11 @@
         @updateValue="updateColorGreen"
       ></controll-slider>
       <controll-slider
-        slider-name="colorBlue"
-        :min-value="0"
-        :max-value="255"
-        :value="colorBlue"
-        @updateValue="updateColorBlue"
+        slider-name="blueSpeed"
+        :min-value="1"
+        :max-value="10"
+        :value="blueSpeed"
+        @updateValue="updateBlueSpeed"
       ></controll-slider>
     </div>
   </div>
@@ -69,8 +69,8 @@ export default {
     colorGreen() {
       return this.$store.state.canvasVariables.colorGreen
     },
-    colorBlue() {
-      return this.$store.state.canvasVariables.colorBlue
+    blueSpeed() {
+      return this.$store.state.canvasVariables.blueSpeed
     }
   },
   mounted() {
@@ -89,8 +89,8 @@ export default {
     updateColorGreen(newValue) {
       this.$store.commit('updateColorGreen', newValue)
     },
-    updateColorBlue(newValue) {
-      this.$store.commit('updateColorBlue', newValue)
+    updateBlueSpeed(newValue) {
+      this.$store.commit('updateBlueSpeed', newValue)
     }
   }
 }

--- a/store/index.js
+++ b/store/index.js
@@ -3,7 +3,7 @@ export const state = () => ({
     rectSize: 50,
     colorRed: 127,
     colorGreen: 127,
-    colorBlue: 127
+    blueSpeed: 1
   }
 })
 
@@ -17,7 +17,7 @@ export const mutations = {
   updateColorGreen(state, value) {
     state.canvasVariables.colorGreen = value
   },
-  updateColorBlue(state, value) {
-    state.canvasVariables.colorBlue = value
+  updateBlueSpeed(state, value) {
+    state.canvasVariables.blueSpeed = value
   }
 }


### PR DESCRIPTION
child of #16 

- 青色を時間経過とサイン波で変化するように変更
- 描画を再帰呼び出しすることでアニメーションに
  - これによって store の subscribe や mount 時の setTimeout が不要になったため削除
- render メソッドを引数を取らない形に変更
- 青色の数値選択 Slider を削除
- 青色の変化速度選択 Slider を追加