### PR TITLE
Refactor controller

### DIFF
--- a/components/atoms/BaseCanvas.vue
+++ b/components/atoms/BaseCanvas.vue
@@ -6,19 +6,11 @@
 
 <script>
 export default {
-  computed: {
-    rectSize() {
-      return this.$store.state.canvasVariables.rectSize
-    },
-    colorRed() {
-      return this.$store.state.canvasVariables.colorRed
-    },
-    colorGreen() {
-      return this.$store.state.canvasVariables.colorGreen
-    },
-    blueSpeed() {
-      return this.$store.state.canvasVariables.blueSpeed
-    }
+  props: {
+    rectSize: { type: Number, required: true, default: 50 },
+    colorRed: { type: Number, required: true, default: 127 },
+    colorGreen: { type: Number, required: true, default: 127 },
+    blueSpeed: { type: Number, required: true, default: 1 }
   },
   mounted() {
     this.ctx = this.$el.getContext('2d')

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -8,6 +8,10 @@
         ref="canvas"
         :width="mainWidth"
         :height="mainHeight"
+        :rect-size="rectSize"
+        :color-red="colorRed"
+        :color-green="colorGreen"
+        :blue-speed="blueSpeed"
       ></base-canvas>
     </div>
     <div class="controller">

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -45,6 +45,8 @@
 </template>
 
 <script>
+import { mapMutations } from 'vuex'
+
 import BaseCanvas from '@/components/atoms/BaseCanvas'
 import ControllSlider from '@/components/molecules/ControllSlider'
 
@@ -80,18 +82,24 @@ export default {
     this.mainHeight = mainArea.offsetHeight
   },
   methods: {
-    updateRectSize(newValue) {
-      this.$store.commit('updateRectSize', newValue)
-    },
-    updateColorRed(newValue) {
-      this.$store.commit('updateColorRed', newValue)
-    },
-    updateColorGreen(newValue) {
-      this.$store.commit('updateColorGreen', newValue)
-    },
-    updateBlueSpeed(newValue) {
-      this.$store.commit('updateBlueSpeed', newValue)
-    }
+    ...mapMutations([
+      'updateRectSize',
+      'updateColorRed',
+      'updateColorGreen',
+      'updateBlueSpeed'
+    ])
+    // updateRectSize(newValue) {
+    //   this.$store.commit('updateRectSize', newValue)
+    // },
+    // updateColorRed(newValue) {
+    //   this.$store.commit('updateColorRed', newValue)
+    // },
+    // updateColorGreen(newValue) {
+    //   this.$store.commit('updateColorGreen', newValue)
+    // },
+    // updateBlueSpeed(newValue) {
+    //   this.$store.commit('updateBlueSpeed', newValue)
+    // }
   }
 }
 </script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -92,18 +92,6 @@ export default {
       'updateColorGreen',
       'updateBlueSpeed'
     ])
-    // updateRectSize(newValue) {
-    //   this.$store.commit('updateRectSize', newValue)
-    // },
-    // updateColorRed(newValue) {
-    //   this.$store.commit('updateColorRed', newValue)
-    // },
-    // updateColorGreen(newValue) {
-    //   this.$store.commit('updateColorGreen', newValue)
-    // },
-    // updateBlueSpeed(newValue) {
-    //   this.$store.commit('updateBlueSpeed', newValue)
-    // }
   }
 }
 </script>


### PR DESCRIPTION
child of #18 

- mutations の記述に mapMutations を使用し簡略化
- BaseCanvas では Store を参照せず props として受け取るように変更