### PR TITLE
Make controllpulldown

### DIFF
--- a/components/atoms/BasePulldown.vue
+++ b/components/atoms/BasePulldown.vue
@@ -31,10 +31,16 @@ export default {
   components: {
     MenuDownIcon
   },
+  props: {
+    valueOptions: {
+      type: Array,
+      required: true,
+      default: () => []
+    }
+  },
   data: () => {
     return {
       currentValue: 0,
-      valueOptions: ['hoge', 'fuga', 'piyo'],
       showOptions: false
     }
   },

--- a/components/atoms/BasePulldown.vue
+++ b/components/atoms/BasePulldown.vue
@@ -52,6 +52,9 @@ export default {
 
 <style lang="scss" scoped>
 // main
+.base-pulldown {
+  position: relative;
+}
 .pulldown-main {
   display: flex;
   justify-content: space-between;
@@ -75,7 +78,7 @@ export default {
 
 // options
 .pulldown-options {
-  width: 208px;
+  width: 100%;
   padding: 0.5rem 0;
   display: none;
   position: absolute;

--- a/components/molecules/ControllPulldown.vue
+++ b/components/molecules/ControllPulldown.vue
@@ -1,0 +1,31 @@
+<template>
+  <div class="controll-pulldown">
+    <div class="pulldown-name">
+      redControll
+    </div>
+    <base-pulldown />
+  </div>
+</template>
+
+<script>
+import BasePulldown from '../atoms/BasePulldown'
+
+export default {
+  components: {
+    BasePulldown
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.controll-pulldown {
+  display: flex;
+}
+.pulldown-name {
+  padding-top: 0.5rem;
+  margin-right: 0.5rem;
+}
+.base-pulldown {
+  flex: 1;
+}
+</style>

--- a/components/molecules/ControllPulldown.vue
+++ b/components/molecules/ControllPulldown.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="controll-pulldown">
     <div class="pulldown-name">
-      redControll
+      {{ pulldownName }}
     </div>
-    <base-pulldown />
+    <base-pulldown :value-options="valueOptions" />
   </div>
 </template>
 
@@ -13,6 +13,14 @@ import BasePulldown from '../atoms/BasePulldown'
 export default {
   components: {
     BasePulldown
+  },
+  props: {
+    pulldownName: { type: String, required: true, default: 'sliderName' },
+    valueOptions: {
+      type: Array,
+      required: true,
+      default: () => []
+    }
   }
 }
 </script>

--- a/components/molecules/ControllSlider.vue
+++ b/components/molecules/ControllSlider.vue
@@ -10,7 +10,7 @@
       :percentage="culcPercentage(value, minValue, maxValue)"
       @clickBar="clickBar($event)"
       @dotMove="dotMove($event)"
-    ></base-slider>
+    />
   </div>
 </template>
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -16,6 +16,7 @@
     </div>
     <div class="controller">
       <base-pulldown />
+      <controll-pulldown />
       <controll-slider
         v-for="(value, name, index) in myStore"
         :key="index"
@@ -37,12 +38,14 @@ import 'vue-material-design-icons/styles.css'
 import BaseCanvas from '@/components/atoms/BaseCanvas'
 import ControllSlider from '@/components/molecules/ControllSlider'
 import BasePulldown from '@/components/atoms/BasePulldown'
+import ControllPulldown from '@/components/molecules/ControllPulldown'
 
 export default {
   components: {
     BaseCanvas,
     ControllSlider,
-    BasePulldown
+    BasePulldown,
+    ControllPulldown
   },
   data() {
     return {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -12,11 +12,13 @@
         :color-red="myStore.colorRed.value"
         :color-green="myStore.colorGreen.value"
         :blue-speed="myStore.blueSpeed.value"
-      ></base-canvas>
+      />
     </div>
     <div class="controller">
-      <base-pulldown />
-      <controll-pulldown />
+      <controll-pulldown
+        pulldown-name="redValue"
+        :value-options="['hoge', 'fuga', 'piyo']"
+      />
       <controll-slider
         v-for="(value, name, index) in myStore"
         :key="index"
@@ -26,7 +28,7 @@
         :value="value.value"
         :unit-name="value.unitName"
         @updateValue="updateValue({ name, value: $event })"
-      ></controll-slider>
+      />
     </div>
   </div>
 </template>
@@ -37,14 +39,12 @@ import { mapMutations } from 'vuex'
 import 'vue-material-design-icons/styles.css'
 import BaseCanvas from '@/components/atoms/BaseCanvas'
 import ControllSlider from '@/components/molecules/ControllSlider'
-import BasePulldown from '@/components/atoms/BasePulldown'
 import ControllPulldown from '@/components/molecules/ControllPulldown'
 
 export default {
   components: {
     BaseCanvas,
     ControllSlider,
-    BasePulldown,
     ControllPulldown
   },
   data() {


### PR DESCRIPTION
child of #10 

- タイトルを含めたレイアウトの作成
- 内容は親から props で渡す形に変更
  - 開閉に関しては変わらず BasePulldown に持たせる